### PR TITLE
Feat/storybook uikit paths

### DIFF
--- a/client/.storybook/webpack.config.js
+++ b/client/.storybook/webpack.config.js
@@ -1,0 +1,17 @@
+const path = require("path");
+
+// Export a function. Accept the base config as the only param.
+module.exports = async ({ config, mode }) => {
+  // `mode` has a value of 'DEVELOPMENT' or 'PRODUCTION'
+  // You can change the configuration based on that.
+  // 'PRODUCTION' is used when building the static version of storybook.
+
+  // Make whatever fine-grained changes you need
+  config.node = {
+    __dirname: true,
+    __filename: true
+  };
+
+  // Return the altered config
+  return config;
+};

--- a/client/stories/index.stories.js
+++ b/client/stories/index.stories.js
@@ -1,19 +1,7 @@
-import React from 'react';
+import { configure } from "@storybook/react";
 
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
-import { linkTo } from '@storybook/addon-links';
-
-import { Button, Welcome } from '@storybook/react/demo';
-
-storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
-
-storiesOf('Button', module)
-  .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
-  .add('with some emoji', () => (
-    <Button onClick={action('clicked')}>
-      <span role="img" aria-label="so cool">
-        😀 😎 👍 💯
-      </span>
-    </Button>
-  ));
+const req = require.context("../uikit", true, /.stories\.js$/);
+function loadStories() {
+  req.keys().forEach(filename => req(filename));
+}
+configure(loadStories, module);

--- a/client/uikit/Button/Nested_Button/stories.js
+++ b/client/uikit/Button/Nested_Button/stories.js
@@ -1,0 +1,10 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import Button from "..";
+
+const NestedButtonStories = storiesOf(`${__dirname}`, module).add(
+  "a basic nested button",
+  () => <Button>I am nested button does folder structure still work?</Button>
+);
+
+export default NestedButtonStories;

--- a/client/uikit/Button/index.js
+++ b/client/uikit/Button/index.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const Button = ({ children }) => <button>{children}</button>;
+
+export default Button;

--- a/client/uikit/Button/stories.js
+++ b/client/uikit/Button/stories.js
@@ -1,0 +1,10 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import Button from ".";
+
+const ButtonStories = storiesOf(`${__dirname}`, module).add(
+  "A basic button",
+  () => <Button>Cognito Argo Sum</Button>
+);
+
+export default ButtonStories;


### PR DESCRIPTION
Components just added to make sure nesting works, these are still a WIP.

Using the `__dirname` scoped to each component so the name isn't tied to the external storybook `index.stories.js`. 

Keeps stories local so they can be added individually to a project but also matches the folder hierarchy from the root 'index.stories.js` require.context include.