### PR TITLE
Feat/webpack absolute paths

### DIFF
--- a/client/uikit/.babelrc
+++ b/client/uikit/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}


### PR DESCRIPTION
fixes errors with absolute import
fixes errors with uikit .babelrc being at root level, moved it into uikit