### PR TITLE
remove readme and test templates from component generate

### DIFF
--- a/client/uikit/plopfile.js
+++ b/client/uikit/plopfile.js
@@ -16,18 +16,8 @@ module.exports = function(plop) {
       },
       {
         type: "add",
-        path: "./{{properCase name}}/readme.md",
-        templateFile: "./template/readme.hbs"
-      },
-      {
-        type: "add",
         path: "./{{properCase name}}/stories.js",
         templateFile: "./template/stories.hbs"
-      },
-      {
-        type: "add",
-        path: "./{{properCase name}}/{{lowerCase name}}.test.js",
-        templateFile: "./template/test.hbs"
       }
     ]
   });


### PR DESCRIPTION
No need to have `readme` or `test` in the create-component generate file
These can be added as the need arises