### PR TITLE
rename API_ROOT to GATEWAY_API_ROOT

### DIFF
--- a/client/.env.schema
+++ b/client/.env.schema
@@ -2,7 +2,7 @@ NODE_PATH=./
 NODE_ENV=development | production
 
 ######### Gateway API
-ARGO_API_ROOT=http://localhost:9000
+GATEWAY_API_ROOT=http://localhost:9000
 
 ######### Ego
 # Base url for Ego API

--- a/client/global/config.js
+++ b/client/global/config.js
@@ -11,7 +11,7 @@ export const ENVIRONMENTS = asEnum(
 );
 
 export const PORT = Number(process.env.PORT) || 8080;
-export const API_ROOT = process.env.API_ROOT || `http://localhost:9000`;
+export const GATEWAY_API_ROOT = process.env.GATEWAY_API_ROOT || `http://localhost:9000`;
 
 export const EGO_API_ROOT = String(process.env.EGO_API_ROOT);
 export const EGO_CLIENT_ID = String(process.env.EGO_CLIENT_ID);

--- a/client/global/utils/getApolloCacheForQueries.js
+++ b/client/global/utils/getApolloCacheForQueries.js
@@ -6,7 +6,7 @@ import { createHttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import fetch from 'isomorphic-fetch';
 
-import { API_ROOT } from 'global/config';
+import { GATEWAY_API_ROOT } from 'global/config';
 import createInMemoryCache from './createInMemoryCache';
 
 export default async (queries: Array<{ query: any, variables?: { [key: string]: any } }>) => {
@@ -14,7 +14,7 @@ export default async (queries: Array<{ query: any, variables?: { [key: string]: 
     ssrMode: typeof window === 'undefined',
     // $FlowFixMe apollo-client and apollo-link-http have a type conflict in their typing
     link: createHttpLink({
-      uri: urlJoin(API_ROOT, '/graphql'),
+      uri: urlJoin(GATEWAY_API_ROOT, '/graphql'),
       fetch: fetch,
     }),
     cache: createInMemoryCache(),

--- a/client/global/utils/runQuery.js
+++ b/client/global/utils/runQuery.js
@@ -2,10 +2,10 @@ import urlJoin from 'url-join';
 import fetch from 'isomorphic-fetch';
 import { print } from 'graphql/language/printer';
 
-import { API_ROOT } from 'global/config';
+import { GATEWAY_API_ROOT } from 'global/config';
 
 export default ({ query, variables }) =>
-  fetch(urlJoin(API_ROOT, 'graphql'), {
+  fetch(urlJoin(GATEWAY_API_ROOT, 'graphql'), {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -19,7 +19,7 @@ export default ({ query, variables }) =>
 export const runBatchQueries = async (queries = []) =>
   !queries.length
     ? await []
-    : fetch(urlJoin(API_ROOT, 'graphql'), {
+    : fetch(urlJoin(GATEWAY_API_ROOT, 'graphql'), {
         method: 'POST',
         headers: {
           'content-type': 'application/json',

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -26,7 +26,7 @@ module.exports = withImages({
   env: {
     ENV: process.env.NODE_ENV,
     PORT: process.env.PORT,
-    API_ROOT: process.env.API_ROOT,
+    GATEWAY_API_ROOT: process.env.GATEWAY_API_ROOT,
     EGO_API_ROOT: process.env.EGO_API_ROOT,
     EGO_CLIENT_ID: process.env.EGO_CLIENT_ID,
   },

--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -14,7 +14,7 @@ import fetch from 'isomorphic-fetch';
 import Button from 'uikit/Button';
 import { ThemeProvider } from 'uikit';
 import { EGO_JWT_KEY, LOGIN_PAGE_PATH } from 'global/constants';
-import { NODE_ENV, ENVIRONMENTS, API_ROOT } from 'global/config';
+import { NODE_ENV, ENVIRONMENTS, GATEWAY_API_ROOT } from 'global/config';
 import { isValidJwt, decodeToken } from 'global/utils/egoJwt';
 import getApolloCacheForQueries from 'global/utils/getApolloCacheForQueries';
 import createInMemoryCache from 'global/utils/createInMemoryCache';
@@ -70,7 +70,7 @@ const Root = (props: {
   const client = new ApolloClient({
     // $FlowFixMe apollo-client and apollo-link-http have a type conflict in their typing
     link: createHttpLink({
-      uri: urlJoin(API_ROOT, '/graphql'),
+      uri: urlJoin(GATEWAY_API_ROOT, '/graphql'),
       fetch: fetch,
       headers: {
         authorization: `Bearer ${props.egoJwt}`,

--- a/client/queryValidations.test.js
+++ b/client/queryValidations.test.js
@@ -11,7 +11,7 @@ import urlJoin from 'url-join';
 
 require('dotenv').config();
 
-const GRAPHQL_URL = urlJoin(process.env.API_ROOT, 'graphql');
+const GRAPHQL_URL = urlJoin(process.env.GATEWAY_API_ROOT, 'graphql');
 
 describe('all gql queries', () => {
   it(`must be compliant with gql API at ${GRAPHQL_URL}`, async () => {


### PR DESCRIPTION
Changes name to be less generic
Updates `.env.schema` to use proper var