### PR TITLE
UpdateProgram in Gateway

### DIFF
--- a/server/schemas/Program/index.js
+++ b/server/schemas/Program/index.js
@@ -76,6 +76,8 @@ const typeDefs = gql`
   }
 
   input UpdateProgramInput {
+    # This intentionally does not provide access to submittedDonors or genomicDonors
+    # Those are maintained by an internal service and should not be updated by any client through the gateway
     name: String
     description: String
     commitmentDonors: Int

--- a/server/services/programService/index.js
+++ b/server/services/programService/index.js
@@ -119,6 +119,9 @@ const updateProgram = async (
   {
     name,
     description,
+    commitmentDonors,
+    submittedDonors,
+    genomicDonors,
     website,
     institutions,
     countries,
@@ -131,7 +134,7 @@ const updateProgram = async (
 ) => {
   const updateProgramRequest = {
     program: {
-      short_name: shortName,
+      short_name: wrapValue(shortName),
       name: wrapValue(name),
       description: wrapValue(description),
       commitment_donors: wrapValue(commitmentDonors),
@@ -139,6 +142,8 @@ const updateProgram = async (
       institutions: wrapValue(institutions),
       countries: wrapValue(countries),
       regions: wrapValue(regions),
+      submitted_donors: wrapValue(submittedDonors),
+      genomic_donors: wrapValue(genomicDonors),
 
       membership_type: wrapValue(membershipType),
 
@@ -199,4 +204,12 @@ const joinProgram = async (
 };
 
 // const inviteUser = async ({programShortName, }, jwt=null)
-export default { getProgram, listPrograms, listUsers, createProgram, inviteUser, joinProgram };
+export default {
+  getProgram,
+  listPrograms,
+  listUsers,
+  createProgram,
+  updateProgram,
+  inviteUser,
+  joinProgram,
+};

--- a/server/services/programService/index.js
+++ b/server/services/programService/index.js
@@ -114,6 +114,48 @@ const createProgram = async (
   });
 };
 
+const updateProgram = async (
+  shortName,
+  {
+    name,
+    description,
+    website,
+    institutions,
+    countries,
+    regions,
+    membershipType,
+    cancerTypes,
+    primarySites,
+  },
+  jwt = null,
+) => {
+  const updateProgramRequest = {
+    program: {
+      short_name: shortName,
+      name: wrapValue(name),
+      description: wrapValue(description),
+      commitment_donors: wrapValue(commitmentDonors),
+      website: wrapValue(website),
+      institutions: wrapValue(institutions),
+      countries: wrapValue(countries),
+      regions: wrapValue(regions),
+
+      membership_type: wrapValue(membershipType),
+
+      cancer_types: cancerTypes,
+      primary_sites: primarySites,
+    },
+  };
+
+  return await new Promise((resolve, reject) => {
+    programService.updateProgram(
+      updateProgramRequest,
+      getAuthMeta(jwt),
+      defaultPromiseCallback(resolve, reject),
+    );
+  });
+};
+
 const inviteUser = async (
   { programShortName, userFirstName, userLastName, userEmail, userRole },
   jwt = null,


### PR DESCRIPTION
There is a hack to deal with a peculiarity of the UpdateProgram service: Before calling update, we call GetProgram to find the current values. The call to UpdateProgram provides all those values for fields that are not desired to be overwritten.

Otherwise, normal gateway service patternz...