### PR TITLE
Revert "Feat/use same version of emotion funcs (#320)"

### DIFF
--- a/client/.storybook/PropTypesTable/ReactTableContainer.js
+++ b/client/.storybook/PropTypesTable/ReactTableContainer.js
@@ -1,4 +1,4 @@
-import { styled } from 'uikit';
+import styled from '@emotion/styled';
 
 export default styled('div')`
   .ReactTable {

--- a/client/components/pages/submission-system/create-program/CreateProgramForm.js
+++ b/client/components/pages/submission-system/create-program/CreateProgramForm.js
@@ -1,4 +1,4 @@
-import { css } from 'uikit';
+import css from '@emotion/css';
 import {
   CANCER_TYPES,
   COUNTRIES,

--- a/client/components/pages/submission-system/create-program/index.js
+++ b/client/components/pages/submission-system/create-program/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { styled, css } from 'uikit';
+import css from '@emotion/css';
+import styled from '@emotion/styled';
 import SubmissionLayout from '../layout';
 import TitleBar from 'uikit/TitleBar';
 import CreateProgramForm from './CreateProgramForm';

--- a/client/components/pages/submission-system/modals/addUser/index.js
+++ b/client/components/pages/submission-system/modals/addUser/index.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { styled, css } from 'uikit';
+import styled from '@emotion/styled';
 import Modal from 'uikit/Modal';
 import Button from 'uikit/Button';
 import Icon from 'uikit/Icon';
 import Typography from 'uikit/Typography';
+import css from '@emotion/css';
 import { UserSection } from '../styledComponents';
 import { addUserSchema } from '../validations';
 import useFormHook from '../useFormHook';

--- a/client/components/pages/submission-system/modals/styledComponents.js
+++ b/client/components/pages/submission-system/modals/styledComponents.js
@@ -3,11 +3,12 @@ import InputLabel from 'uikit/form/InputLabel';
 import MultiSelect from 'uikit/form/MultiSelect';
 import Input from 'uikit/form/Input';
 import FormControl from 'uikit/form/FormControl';
-import { styled, css } from 'uikit';
+import styled from '@emotion/styled';
 import Icon from 'uikit/Icon';
 import Select from 'uikit/form/Select';
 import FormHelperText from 'uikit/form/FormHelperText';
 import { PROGRAM_MEMBERSHIP_TYPES } from 'global/constants';
+import css from '@emotion/css';
 import PropTypes from 'prop-types';
 
 import { Row, Col } from 'react-grid-system';

--- a/client/uikit/AppBar/DropdownMenu.js
+++ b/client/uikit/AppBar/DropdownMenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { styled, css } from '../';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 import clsx from 'clsx';
 
 const Ul = styled('ul')`

--- a/client/uikit/AppBar/styledComponents.js
+++ b/client/uikit/AppBar/styledComponents.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '../';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { withProps } from 'recompose';
 

--- a/client/uikit/Button/GoogleLogin/index.js
+++ b/client/uikit/Button/GoogleLogin/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '../../';
+import styled from '@emotion/styled';
 import Button from '../index';
 import Icon from '../../Icon';
+import css from '@emotion/css';
 import useTheme from '../../utils/useTheme';
 
 /**

--- a/client/uikit/Button/index.js
+++ b/client/uikit/Button/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '../';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import Icon from '../Icon';
 import useTheme from '../utils/useTheme';

--- a/client/uikit/Container/index.js
+++ b/client/uikit/Container/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '..';
+import styled from '@emotion/styled';
 
 const Container = styled('div')`
   border-radius: 8px;

--- a/client/uikit/DnaLoader/index.js
+++ b/client/uikit/DnaLoader/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '..';
+import styled from '@emotion/styled-base';
+import css from '@emotion/css';
+
 import { range } from 'lodash';
 
 const LoaderContainer = styled('div')`

--- a/client/uikit/FocusWrapper/index.js
+++ b/client/uikit/FocusWrapper/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '..';
+import styled from '@emotion/styled-base';
 
 const FocusWrapper = styled('button')`
   border: none;

--- a/client/uikit/Footer/index.js
+++ b/client/uikit/Footer/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '..';
+import styled from '@emotion/styled';
 import Icon from '../Icon';
 import icgcLogo from '../assets/icgc_logo.svg';
+import css from '@emotion/css';
 import { Row, Col, Container as GridContainer } from 'react-grid-system';
 import A from '../Link';
 

--- a/client/uikit/PageLayout/index.js
+++ b/client/uikit/PageLayout/index.js
@@ -1,4 +1,5 @@
-import { styled, css } from '..';
+import css from '@emotion/css';
+import styled from '@emotion/styled';
 import Container from '../Container';
 
 export const PageContainer = styled('div')`

--- a/client/uikit/PageLayout/stories.js
+++ b/client/uikit/PageLayout/stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import { css } from '..';
+import css from '@emotion/css';
 
 import AppBar, { MenuItem } from '../AppBar';
 import Typography from '../Typography';

--- a/client/uikit/PercentageBar/stories.js
+++ b/client/uikit/PercentageBar/stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import { css } from '..';
+import css from '@emotion/css';
 import { number, select } from '@storybook/addon-knobs';
 
 import defaultTheme from '../theme/defaultTheme';

--- a/client/uikit/SubMenu/index.js
+++ b/client/uikit/SubMenu/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '..';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 
 import Icon from '../Icon';
 import useTheme from '../utils/useTheme';

--- a/client/uikit/SubMenu/styledComponents.js
+++ b/client/uikit/SubMenu/styledComponents.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { styled, css } from '..';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 
 const defaultLabelStyle = ({ selected, theme }) => css`
   & > .MenuItemContent {

--- a/client/uikit/Table/TablePagination/index.js
+++ b/client/uikit/Table/TablePagination/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { styled, css } from '../..';
+import css from '@emotion/css';
+import styled from '@emotion/styled';
 
 import Typography from '../../Typography';
 import useTheme from '../../utils/useTheme';

--- a/client/uikit/Table/styledComponent.js
+++ b/client/uikit/Table/styledComponent.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { styled, css } from '..';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 import ReactTable from 'react-table';
 
 import reactTableDefaultStyle from './reactTableDefaultStyle';

--- a/client/uikit/Tabs/index.js
+++ b/client/uikit/Tabs/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '..';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 import clsx from 'clsx';
 import useTheme from '../utils/useTheme';
 

--- a/client/uikit/Tag/index.js
+++ b/client/uikit/Tag/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { styled, css } from '..';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 /* import PropTypes from 'prop-types'; */
 
 const Tag = styled('div')`

--- a/client/uikit/TitleBar/index.js
+++ b/client/uikit/TitleBar/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '..';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 import Icon from '../Icon';
 import useTheme from '../utils/useTheme';
 

--- a/client/uikit/Typography/index.js
+++ b/client/uikit/Typography/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '..';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { memoize } from 'lodash';
 

--- a/client/uikit/form/Checkbox/index.js
+++ b/client/uikit/form/Checkbox/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '../..';
+import styled from '@emotion/styled';
 
 /**
  * Checkbox styles

--- a/client/uikit/form/FormCheckbox/index.js
+++ b/client/uikit/form/FormCheckbox/index.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { RadioCheckboxWrapper, StyledGroup } from '../common';
 import Checkbox from '../Checkbox';
-import { css } from '../..';
+import css from '@emotion/css';
 import RadioCheckContext from '../RadioCheckboxGroup/RadioCheckContext';
 
 /**

--- a/client/uikit/form/FormControl/index.js
+++ b/client/uikit/form/FormControl/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FormControlContext from './FormControlContext';
-import { css } from '../..';
+import css from '@emotion/css';
 
 const FormControl = React.forwardRef(function FormControl(
   {

--- a/client/uikit/form/FormHelperText/index.js
+++ b/client/uikit/form/FormHelperText/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FormControlContext from '../FormControl/FormControlContext';
-import { styled, css } from '../..';
+import styled from '@emotion/styled';
 import clsx from 'clsx';
+import css from '@emotion/css';
 import _ from 'lodash';
 
 const FormHelperText = React.forwardRef(function FormHelperText(props, ref) {

--- a/client/uikit/form/FormRadio/index.js
+++ b/client/uikit/form/FormRadio/index.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { RadioCheckboxWrapper, StyledGroup } from '../common';
 import Radio from '../Radio';
-import { css } from '../..';
+import css from '@emotion/css';
 import RadioCheckContext from '../RadioCheckboxGroup/RadioCheckContext';
 
 /**

--- a/client/uikit/form/Input/index.js
+++ b/client/uikit/form/Input/index.js
@@ -5,7 +5,7 @@ import Icon from '../../Icon';
 import { INPUT_SIZES, StyledInputWrapper } from '../common';
 import { StyledInput, IconWrapper } from './styledComponents';
 import FormControlContext from '../FormControl/FormControlContext';
-import { css } from '../..';
+import css from '@emotion/css';
 
 export const INPUT_PRESETS = {
   DEFAULT: 'default',

--- a/client/uikit/form/Input/styledComponents.js
+++ b/client/uikit/form/Input/styledComponents.js
@@ -1,4 +1,4 @@
-import { styled } from '../..';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 export { StyledInputWrapper } from '../common';

--- a/client/uikit/form/InputLabel/index.js
+++ b/client/uikit/form/InputLabel/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FormControlContext from '../FormControl/FormControlContext';
-import { styled, css } from '../..';
+import styled from '@emotion/styled';
 import clsx from 'clsx';
+import css from '@emotion/css';
 import Icon from '../../Icon';
 import _ from 'lodash';
 

--- a/client/uikit/form/MultiSelect/Option.js
+++ b/client/uikit/form/MultiSelect/Option.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '../..';
+import styled from '@emotion/styled';
 
 const Li = styled('li')`
   list-style: none;

--- a/client/uikit/form/MultiSelect/index.js
+++ b/client/uikit/form/MultiSelect/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '../..';
+import styled from '@emotion/styled';
 import Icon from '../../Icon';
 import Option from './Option';
+import css from '@emotion/css';
 import _ from 'lodash';
 import Tag from '../../Tag';
 import useTheme from '../../utils/useTheme';

--- a/client/uikit/form/Radio/index.js
+++ b/client/uikit/form/Radio/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { styled, css } from '../..';
+import styled from '@emotion/styled';
+import css from '@emotion/css';
 
 /*
  * :before

--- a/client/uikit/form/Select/index.js
+++ b/client/uikit/form/Select/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '..';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { withProps } from 'recompose';
 

--- a/client/uikit/form/Select/styledComponents.js
+++ b/client/uikit/form/Select/styledComponents.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '../..';
+import styled from '@emotion/styled';
 import { withProps } from 'recompose';
 
 import Icon from '../../Icon';

--- a/client/uikit/form/Textarea/index.js
+++ b/client/uikit/form/Textarea/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import useTheme from '../../utils/useTheme';
 
-import { css } from '../..';
+import css from '@emotion/css';
 import FormControlContext from '../FormControl/FormControlContext';
 
 const Textarea = ({ error, disabled, className, ...props }) => {

--- a/client/uikit/form/common.js
+++ b/client/uikit/form/common.js
@@ -1,4 +1,4 @@
-import { styled } from '..';
+import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { Row, Col } from 'react-grid-system';


### PR DESCRIPTION
This reverts commit c364e01222a4ed1070db1b498b0397f6014a046f.

**Description of changes**

Reverts Emotion imports.
Centralising the imports to use uikit caused this error: https://github.com/emotion-js/emotion/issues/1346

**Type of Change**
- [ x ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches deisgn:
* component sizes, spacing, and styless
* font size, weight, colour
* spelling has been double checked
- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
