### PR TITLE
use standard modal implementation for ResendEmailModal

### DIFF
--- a/client/components/pages/submission-system/program-management/Users.js
+++ b/client/components/pages/submission-system/program-management/Users.js
@@ -12,19 +12,17 @@ import EDIT_USER_MUTATION from './EDIT_USER_MUTATION.gql';
 
 function ResendEmailModal({ user, ...otherProps }) {
   return (
-    <Modal.Overlay>
-      <Modal
-        title="Resend Invitation?"
-        actionButtonText="RESEND INVITATION"
-        cancelText="CANCEL"
-        {...otherProps}
-      >
-        <div style={{ width: '322px' }}>
-          Are you sure you want to resend the email invitation to{' '}
-          <strong>{user ? user.name : ''}</strong>?
-        </div>
-      </Modal>
-    </Modal.Overlay>
+    <Modal
+      title="Resend Invitation?"
+      actionButtonText="RESEND INVITATION"
+      cancelText="CANCEL"
+      {...otherProps}
+    >
+      <div style={{ width: '322px' }}>
+        Are you sure you want to resend the email invitation to{' '}
+        <strong>{user ? user.name : ''}</strong>?
+      </div>
+    </Modal>
   );
 }
 
@@ -69,12 +67,14 @@ const Users = ({ users, programShortName }) => {
         onUserEditClick={({ user }) => setCurrentEditingUser(user)}
       />
       {isResendEmailModalOpen && (
-        <ResendEmailModal
-          user={user}
-          onCancelClick={handleModalCancelClick}
-          onCloseClick={handleModalCancelClick}
-          onActionClick={handleActionClick}
-        />
+        <ModalPortal>
+          <ResendEmailModal
+            user={user}
+            onCancelClick={handleModalCancelClick}
+            onCloseClick={handleModalCancelClick}
+            onActionClick={handleActionClick}
+          />
+        </ModalPortal>
       )}
       <Portal selector="body">
         <Fade in={isToastOpen}>

--- a/client/uikit/Modal/index.js
+++ b/client/uikit/Modal/index.js
@@ -42,12 +42,8 @@ const ButtonContainer = styled('div')`
   flex-direction: row;
 `;
 const ModalOverlay = styled('div')`
-  position: fixed;
-  z-index: 9999;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -155,13 +151,7 @@ const Modal = ({
   </ModalContainer>
 );
 
-Modal.Overlay = props => {
-  return (
-    <Portal selector="body">
-      <ModalOverlay {...props} />
-    </Portal>
-  );
-};
+Modal.Overlay = props => <ModalOverlay {...props} />;
 
 Modal.propTypes = {
   title: PropTypes.node,


### PR DESCRIPTION
**Description of changes**

just refactored to use the standard modal implementation for ResendEmailModal which had its own thing before that messed with the modal storybook

**Type of Change**

- [x] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:
    * component sizes, spacing, and styles
    * font size, weight, colour
    * spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
