### PR TITLE
fix app bar menu item ref

### DIFF
--- a/client/uikit/AppBar/index.js
+++ b/client/uikit/AppBar/index.js
@@ -91,8 +91,9 @@ export const MenuItem = React.forwardRef(
       DomComponent = ({ active, ...others }) => <a {...others} />,
       dropdownMenu,
     },
-    ref,
+    forwardedRef,
   ) => {
+    const ref = forwardedRef || React.createRef();
     const [isDropdownOpen, setDropdownOpen] = React.useState(false);
 
     useClickAway({

--- a/client/uikit/AppBar/index.js
+++ b/client/uikit/AppBar/index.js
@@ -125,8 +125,8 @@ MenuItem.propTypes = {
   DomComponent: PropTypes.func,
   dropdownMenu: PropTypes.node,
   ref: PropTypes.shape({
-    current: PropTypes.any.isRequired,
-  }).isRequired,
+    current: PropTypes.any,
+  }),
 };
 
 const AppBar = AppBarContainer;


### PR DESCRIPTION
**Description of changes**

Storybook was breaking for the story because ref wasn't passed in. It shouldn't be a required prop anyway.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
