### PR TITLE
 adds ability to add toast with custom timeout

### DIFF
--- a/client/components/pages/submission-system/toaster.js
+++ b/client/components/pages/submission-system/toaster.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import omit from 'lodash/omit';
 import { TOAST_VARIANTS } from 'uikit/notifications/Toast';
 import { NOTIFICATION_INTERACTION_EVENTS } from 'uikit/notifications/Notification';
 
@@ -12,10 +13,10 @@ type ToastConfig = {
   onInteraction?: (e: ToastEventPayload) => any,
 };
 export const useToastState = () => {
-  const DISMISS_TIMEOUT = 8000;
+  const DEFAULT_TIMEOUT = 8000;
   const [toastStack, setToastStack] = React.useState<(ToastConfig & { id: string })[]>([]);
 
-  const addToast = (toast: ToastConfig) => {
+  const addToast = (toast: ToastConfig & { timeout?: number }) => {
     console.log(`🔥🍞🍞🍞🍞🍞🍞🔥`);
     console.log(`🔥🔥🔥🔥🔥🔥🔥🔥`);
     const id = String(Math.random());
@@ -24,10 +25,15 @@ export const useToastState = () => {
       onInteraction: e => e,
       interactionType: undefined, // the Toast component internally has its default, no need to cover this
     };
-    setToastStack(toastStack => [...toastStack, { ...DEFAULT_TOAST_CONFIGS, ...toast, id }]);
-    setTimeout(() => {
-      removeToast(id);
-    }, DISMISS_TIMEOUT);
+    setToastStack(toastStack => [
+      ...toastStack,
+      { ...DEFAULT_TOAST_CONFIGS, ...omit(toast, 'timeout'), id },
+    ]);
+    if (toast.timeout !== Infinity) {
+      setTimeout(() => {
+        removeToast(id);
+      }, toast.timeout || DEFAULT_TIMEOUT);
+    }
     return id;
   };
 


### PR DESCRIPTION
**Description of changes**

Adds ability to add toast with custom timeout. `timeout` is available in `addToast` only and isn't added to the props fed to `ToastStack` component

**Type of Change**

- [ ] Bug
- [ ] Styling
- [X] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [X] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
