### PR TITLE
SIDE_MENU_PROGRAM_LIST pre-render

### DIFF
--- a/client/components/pages/submission-system/SIDE_MENU_PROGRAM_LIST.gql
+++ b/client/components/pages/submission-system/SIDE_MENU_PROGRAM_LIST.gql
@@ -1,4 +1,4 @@
-query sideMenuProgramList {
+query SIDE_MENU_PROGRAM_LIST {
   programs {
     shortName
   }

--- a/client/components/pages/submission-system/SideMenu.js
+++ b/client/components/pages/submission-system/SideMenu.js
@@ -13,8 +13,7 @@ import DnaLoader from 'uikit/DnaLoader';
 
 import { mockPrograms } from './mockData';
 
-// $FlowFixMe .gql file not supported
-import { sideMenuProgramList } from './queries.gql';
+import SIDE_MENU_PROGRAM_LIST from './SIDE_MENU_PROGRAM_LIST.gql';
 import useAuthContext from 'global/hooks/useAuthContext';
 import { isDccMember, getAuthorizedProgramScopes, canWriteProgram } from 'global/utils/egoJwt';
 
@@ -192,7 +191,7 @@ export default () => {
     data: { programs = [] } = {},
     loading,
   }: { data: { programs: Array<SideMenuProgram> }, loading: boolean } = useQuery(
-    sideMenuProgramList,
+    SIDE_MENU_PROGRAM_LIST,
   );
 
   const { data: egoTokenData, token } = useAuthContext();

--- a/client/pages/submission/program/[shortName]/clinical-submission.js
+++ b/client/pages/submission/program/[shortName]/clinical-submission.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { createPage } from 'global/utils/pages';
 import programClinicalSubmission from 'components/pages/submission-system/program-clinical-submission';
 import { isRdpcMember, canReadProgram } from 'global/utils/egoJwt';
+import SIDE_MENU_PROGRAM_LIST from 'components/pages/submission-system/SIDE_MENU_PROGRAM_LIST.gql';
 
 export default createPage({
   isPublic: false,
@@ -13,4 +14,5 @@ export default createPage({
     } = ctx;
     return !isRdpcMember(egoJwt) && canReadProgram({ egoJwt, programId: shortName });
   },
+  getGqlQueriesToPrefetch: async () => [{ query: SIDE_MENU_PROGRAM_LIST }],
 })(programClinicalSubmission);

--- a/client/pages/submission/program/[shortName]/dashboard.js
+++ b/client/pages/submission/program/[shortName]/dashboard.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { createPage } from 'global/utils/pages';
 import ProgramDashboard from 'components/pages/submission-system/program-dashboard';
 import { isRdpcMember, canReadProgram } from 'global/utils/egoJwt';
+import SIDE_MENU_PROGRAM_LIST from 'components/pages/submission-system/SIDE_MENU_PROGRAM_LIST.gql';
 
 export default createPage({
   isPublic: false,
@@ -13,4 +14,5 @@ export default createPage({
     } = ctx;
     return !isRdpcMember(egoJwt) && canReadProgram({ egoJwt, programId: shortName });
   },
+  getGqlQueriesToPrefetch: async () => [{ query: SIDE_MENU_PROGRAM_LIST }],
 })(ProgramDashboard);

--- a/client/pages/submission/program/[shortName]/id-registration.js
+++ b/client/pages/submission/program/[shortName]/id-registration.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { createPage } from 'global/utils/pages';
 import programIDRegistration from 'components/pages/submission-system/program-id-registration';
 import { isRdpcMember, canReadProgram } from 'global/utils/egoJwt';
+import SIDE_MENU_PROGRAM_LIST from 'components/pages/submission-system/SIDE_MENU_PROGRAM_LIST.gql';
 
 export default createPage({
   isPublic: false,
@@ -13,4 +14,5 @@ export default createPage({
     } = ctx;
     return !isRdpcMember(egoJwt) && canReadProgram({ egoJwt, programId: shortName });
   },
+  getGqlQueriesToPrefetch: async () => [{ query: SIDE_MENU_PROGRAM_LIST }],
 })(programIDRegistration);

--- a/client/pages/submission/program/[shortName]/manage.js
+++ b/client/pages/submission/program/[shortName]/manage.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { createPage } from 'global/utils/pages';
 import ProgramManagement from 'components/pages/submission-system/program-management';
 import { isRdpcMember, isProgramAdmin } from 'global/utils/egoJwt';
+import SIDE_MENU_PROGRAM_LIST from 'components/pages/submission-system/SIDE_MENU_PROGRAM_LIST.gql';
 
 export default createPage({
   isPublic: false,
@@ -13,4 +14,5 @@ export default createPage({
     } = ctx;
     return !isRdpcMember(egoJwt) && isProgramAdmin({ egoJwt, programId: shortName });
   },
+  getGqlQueriesToPrefetch: async () => [{ query: SIDE_MENU_PROGRAM_LIST }],
 })(ProgramManagement);

--- a/client/pages/submission/program/index.js
+++ b/client/pages/submission/program/index.js
@@ -4,12 +4,12 @@ import React from 'react';
 import { isRdpcMember, isDccMember } from 'global/utils/egoJwt';
 import { createPage } from 'global/utils/pages';
 import ProgramsPage from 'components/pages/submission-system/programs';
+import SIDE_MENU_PROGRAM_LIST from 'components/pages/submission-system/SIDE_MENU_PROGRAM_LIST.gql';
 
-// $FlowFixMe .gql file not supported
-import { programsListQuery } from 'components/pages/submission-system/programs/queries.gql';
+import programsListQuery from 'components/pages/submission-system/programs/queries.gql';
 
 export default createPage({
   isPublic: false,
   isAccessible: async ({ egoJwt, ctx }) => isDccMember(egoJwt),
-  getGqlQueriesToPrefetch: async () => [{ query: programsListQuery }],
+  getGqlQueriesToPrefetch: async () => [{ query: SIDE_MENU_PROGRAM_LIST }],
 })(ProgramsPage);


### PR DESCRIPTION
… side

**Description of changes**

Basically pre-resolve the `SIDE_MENU_PROGRAM_LIST` graphql query on the server side so browser doesn't have to. This would help with reducing the flashing of the side menu when navigating.

`getGqlQueriesToPrefetch` is something we always had, just never used.

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
