### PR TITLE
updates @icgc-argo/ego-token-utils

### DIFF
--- a/client/global/utils/egoJwt/index.js
+++ b/client/global/utils/egoJwt/index.js
@@ -3,7 +3,7 @@ import jwtDecode from 'jwt-decode';
 import { get, memoize } from 'lodash';
 
 // $FlowFixMe
-import createEgoUtils from '@icgc-argo/ego-token-utils/dist/lib/ego-token-utils';
+import createEgoUtils from '@icgc-argo/ego-token-utils';
 
 const TokenUtils = createEgoUtils();
 type EgoJwtData = {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1141,9 +1141,9 @@
       "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
     },
     "@icgc-argo/ego-token-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@icgc-argo/ego-token-utils/-/ego-token-utils-4.0.0.tgz",
-      "integrity": "sha512-nUSL2mzfwjzxGIUkprsvU/LqD0yvgBhj9j8vW+SaG4VVmXIb2IzNrSyoXsvMcMOG7DII06ET2kDoW6Sw7lBxkg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@icgc-argo/ego-token-utils/-/ego-token-utils-5.0.0.tgz",
+      "integrity": "sha512-EBgovhQPka63Mc+llWMjlVKr2a5c6FTg6RewINZpMGCmu4PCCRpNDB6/LrMvYIoB+iQsReCr2OzxbIcQpyNnnA==",
       "requires": {
         "@types/jwt-decode": "^2.2.1",
         "jwt-decode": "^2.2.0"

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "@emotion/babel-preset-css-prop": "^10.0.9",
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.11",
-    "@icgc-argo/ego-token-utils": "^4.0.0",
+    "@icgc-argo/ego-token-utils": "^5.0.0",
     "@storybook/addon-a11y": "^5.1.9",
     "apollo-cache-inmemory": "^1.6.2",
     "apollo-client": "^2.6.3",


### PR DESCRIPTION
**Description of changes**

Updates to the latest `@icgc-argo/ego-token-utils` which got the dependency bundling problem fixed.

`@icgc-argo/ego-token-utils`'s build didn't bundle dependencies before so imports had to be done against the `/dist/lib/ego-token-utils` path